### PR TITLE
REF: refactor ldap-based PLC host discovery main entrypoint into class

### DIFF
--- a/ads_log_daemon/client.py
+++ b/ads_log_daemon/client.py
@@ -6,7 +6,6 @@ import datetime
 import enum
 import json
 import logging
-import random
 import time
 from typing import Any, Dict, List, Optional, Tuple, cast
 
@@ -475,15 +474,6 @@ class ClientLogger:
         self, client: AsyncioClientConnection, circuit: AsyncioClientCircuit
     ) -> None:
         """Run on initial connection to the PLC."""
-        # TODO: I think handles may clash between connections somehow?
-        # Start these off beyond the default of 100.
-        # Either that or we're just supposed to ignore messages bound
-        # for other destinations... ?
-        starting_counter = random.randint(500, 65535)
-        circuit.circuit._handle_counter.value = starting_counter
-        circuit.circuit._notification_counter.value = starting_counter
-        circuit.circuit._invoke_counter.value = starting_counter
-
         await self._update_device_info(
             circuit=circuit,
             timeout=2.0,

--- a/ads_log_daemon/client.py
+++ b/ads_log_daemon/client.py
@@ -675,8 +675,6 @@ class ClientLogger:
         if circuit is None:
             return
 
-        await self.plc.update_service_information()
-
         await self.log(
             create_status_message(
                 message=f"Logging daemon now monitoring {self.plc.description}",

--- a/ads_log_daemon/client.py
+++ b/ads_log_daemon/client.py
@@ -589,8 +589,12 @@ class ClientLogger:
                     log_task = asyncio.create_task(self._start_logging(client, circuit))
                     self._log_task = log_task
                     await self._keepalive(client, circuit)
-        except DisconnectedError:
-            logger.debug("Disconnected from plc: %s", self.plc.description)
+        except (asyncio.TimeoutError, DisconnectedError) as ex:
+            logger.debug(
+                "Disconnected from plc (%s): %s",
+                ex.__class__.__name__,
+                self.plc.description,
+            )
             if connection_initialized:
                 await self.log(
                     create_status_message(

--- a/ads_log_daemon/client.py
+++ b/ads_log_daemon/client.py
@@ -534,6 +534,12 @@ class ClientLogger:
         finally:
             if log_task is not None:
                 log_task.cancel()
+
+                try:
+                    await log_task
+                except Exception:
+                    ...
+
             self.client = None
             self.circuit = None
             self.running = False
@@ -712,4 +718,8 @@ class ClientLogger:
         log_task = self._log_task
         if log_task is not None:
             log_task.cancel()
+            try:
+                await log_task
+            except Exception:
+                ...
             self._log_task = None

--- a/ads_log_daemon/client.py
+++ b/ads_log_daemon/client.py
@@ -300,7 +300,7 @@ class PlcInformation:
             try:
                 return next(_get_plc_info(plc_hostname, timeout=timeout))
             except StopIteration:
-                raise TimeoutError() from None
+                raise asyncio.TimeoutError() from None
 
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, inner)
@@ -318,7 +318,7 @@ class PlcInformation:
                 service_info = await self._get_plc_info_via_service_port_async(
                     self.address
                 )
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 self.service_query_fail_count += 1
                 if (self.service_query_fail_count % 60) == 0:
                     # First time and every hour, maybe.
@@ -371,7 +371,7 @@ class PlcInformation:
             project_name = await get_or_fallback(circuit.get_project_name(), "")
             app_name = await get_or_fallback(circuit.get_app_name(), "")
             task_id_to_name = await get_or_fallback(circuit.get_task_names(), {})
-        except (TimeoutError, DisconnectedError) as ex:
+        except (asyncio.TimeoutError, DisconnectedError) as ex:
             raise DisconnectedError(f"Unable to read device information: {ex}") from ex
 
         task_names = list(task_id_to_name.values())
@@ -554,7 +554,7 @@ class ClientLogger:
                     timeout=LOG_DAEMON_KEEPALIVE,
                 )
                 await asyncio.sleep(LOG_DAEMON_KEEPALIVE)
-        except (TimeoutError, DisconnectedError, asyncio.CancelledError) as ex:
+        except (asyncio.TimeoutError, DisconnectedError, asyncio.CancelledError) as ex:
             logger.warning(
                 "Keepalive exiting for %s due to %s %s",
                 self.plc.description,

--- a/ads_log_daemon/client.py
+++ b/ads_log_daemon/client.py
@@ -129,9 +129,13 @@ def to_logstash(
     if severity is None:
         severity = MessageType(int(message.unknown)).to_severity()
 
+    # TODO: always using system time for now
+    # timestamp = time.time() if use_system_time else message.timestamp.timestamp()
+    timestamp = time.time()
+
     return {
         "schema": "twincat-event-0",
-        "ts": time.time() if use_system_time else message.timestamp.timestamp(),
+        "ts": timestamp,
         "severity": severity,
         "id": 0,  # hmm
         "event_class": "C0FFEEC0-FFEE-COFF-EECO-FFEEC0FFEEC0",

--- a/ads_log_daemon/client.py
+++ b/ads_log_daemon/client.py
@@ -476,7 +476,7 @@ class ClientLogger:
                         timeout=LOG_DAEMON_KEEPALIVE,
                     )
                     await asyncio.sleep(LOG_DAEMON_KEEPALIVE)
-            except asyncio.CancelledError as ex:
+            except (TimeoutError, asyncio.CancelledError) as ex:
                 logger.warning(
                     "Keepalive exiting for %s due to %s",
                     self.plc.description,

--- a/ads_log_daemon/client.py
+++ b/ads_log_daemon/client.py
@@ -676,9 +676,10 @@ class ClientLogger:
             return
 
         await self.plc.update_service_information()
+
         await self.log(
             create_status_message(
-                message=f"Logging daemon connected to and monitoring {self.plc.name!r}",
+                message=f"Logging daemon now monitoring {self.plc.description}",
                 custom_json=self.plc.asdict(),
             )
         )

--- a/ads_log_daemon/client.py
+++ b/ads_log_daemon/client.py
@@ -228,9 +228,9 @@ class PlcInformation:
         ]
         if self.host_name != self.address:
             info.append(f"({self.host_name})")
-        if self.name != self.host_name and self.name is not None:
+        if self.name != self.host_name and self.name:
             info.append(f"PLC {self.name!r}")
-        if self.application_name != self.name and self.application_name is not None:
+        if self.application_name != self.name and self.application_name:
             info.append(f"running application {self.application_name!r}")
         return " ".join(info)
 
@@ -516,6 +516,7 @@ class ClientLogger:
             if client is not None:
                 try:
                     await client.close()
+                    await client.user_callback_executor.shutdown()
                 except OSError:
                     # Actually disconnected; don't worry
                     ...

--- a/ads_log_daemon/client.py
+++ b/ads_log_daemon/client.py
@@ -7,7 +7,7 @@ import enum
 import json
 import logging
 import time
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, Optional, Tuple, cast
 
 import ads_async
 from ads_async import constants, structs
@@ -239,7 +239,7 @@ class PlcInformation:
     #: ads-log-daemon.
     clock_incorrect: Optional[bool] = None
     #: The task names running on the PLC.
-    task_names: List[str] = dataclasses.field(default_factory=list)
+    tasks: str = ""
     #: Metadata from LDAP about the PLC host, if available.
     ldap_metadata: Dict[str, Any] = dataclasses.field(default_factory=dict)
     #: Information retrieved from the UDP PLC service port.
@@ -373,17 +373,15 @@ class PlcInformation:
             device_info = await circuit.get_device_information()
             project_name = await get_or_fallback(circuit.get_project_name(), "")
             app_name = await get_or_fallback(circuit.get_app_name(), "")
-            task_id_to_name = await get_or_fallback(circuit.get_task_names(), {})
+            tasks = await get_or_fallback(circuit.get_task_names(), {})
         except (asyncio.TimeoutError, DisconnectedError) as ex:
             raise DisconnectedError(f"Unable to read device information: {ex}") from ex
-
-        task_names = list(task_id_to_name.values())
 
         new_info = {
             "version": "{}.{}.{}".format(*device_info.version.as_tuple),
             "device_info_name": device_info.name,
             "project_name": project_name,
-            "task_names": task_names,
+            "tasks": ", ".join(tasks.values()),
             "application_name": app_name,
             # Can also get like `stLibVersion_Tc3_Module` or for LCLS general, etc.
         }

--- a/ads_log_daemon/config.py
+++ b/ads_log_daemon/config.py
@@ -26,7 +26,7 @@ LOG_DAEMON_INFO_PERIOD = int(os.environ.get("LOG_DAEMON_INFO_PERIOD", "60"))
 # Search LDAP at this rate (every 15 mins) for new/removed hosts:
 LOG_DAEMON_SEARCH_PERIOD = int(os.environ.get("LOG_DAEMON_SEARCH_PERIOD", "900"))
 # Reconnect to disconnected PLCs at this rate (2 minutes):
-LOG_DAEMON_RECONNECT_PERIOD = int(os.environ.get("LOG_DAEMON_RECONNECT_PERIOD", "120"))
+LOG_DAEMON_RECONNECT_PERIOD = int(os.environ.get("LOG_DAEMON_RECONNECT_PERIOD", "300"))
 
 LOG_DAEMON_HOST_PREFIXES = os.environ.get(
     "LOG_DAEMON_HOST_PREFIXES", "plc-*,bhc-*"

--- a/ads_log_daemon/config.py
+++ b/ads_log_daemon/config.py
@@ -1,5 +1,7 @@
+import ipaddress
 import os
 import socket
+import sys
 
 # Host and AMS Net ID of the daemon:
 LOG_DAEMON_HOST = os.environ.get("LOG_DAEMON_HOST", "172.21.32.90")
@@ -45,3 +47,10 @@ LOG_DAEMON_TIMESTAMP_THRESHOLD = int(
 # Query the PLC for project updates at this rate - this acts as a keepalive
 # for the connection:
 LOG_DAEMON_KEEPALIVE = int(os.environ.get("LOG_DAEMON_KEEPALIVE", 120))
+
+
+try:
+    ipaddress.IPv4Address(LOG_DAEMON_HOST)
+except Exception:
+    print(f"Invalid configuration setting: LOG_DAEMON_HOST={LOG_DAEMON_HOST}")
+    sys.exit(1)

--- a/ads_log_daemon/config.py
+++ b/ads_log_daemon/config.py
@@ -23,6 +23,8 @@ LOG_DAEMON_ENCODING = os.environ.get("LOG_DAEMON_ENCODING", "utf-8")
 LOG_DAEMON_INFO_PERIOD = int(os.environ.get("LOG_DAEMON_INFO_PERIOD", "60"))
 # Search LDAP at this rate (every 15 mins) for new/removed hosts:
 LOG_DAEMON_SEARCH_PERIOD = int(os.environ.get("LOG_DAEMON_SEARCH_PERIOD", "900"))
+# Reconnect to disconnected PLCs at this rate (2 minutes):
+LOG_DAEMON_RECONNECT_PERIOD = int(os.environ.get("LOG_DAEMON_RECONNECT_PERIOD", "120"))
 
 LOG_DAEMON_HOST_PREFIXES = os.environ.get(
     "LOG_DAEMON_HOST_PREFIXES", "plc-*,bhc-*"

--- a/ads_log_daemon/ldap_helper.py
+++ b/ads_log_daemon/ldap_helper.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import ldap
 
 from .config import (
@@ -108,3 +110,20 @@ class LDAPHelper:
 
         self._last_hosts = added_hosts
         return removed_hosts, added_hosts
+
+    async def update_hosts_async(self):
+        """
+        Update hosts dictionary with the LDAP client.
+
+        After an update, refer to the ``.hosts`` dictionary.
+
+        Returns
+        -------
+        removed : set
+            Removed host names.
+
+        added : set
+            Added host names.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.update_hosts)

--- a/ads_log_daemon/logstash.py
+++ b/ads_log_daemon/logstash.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from .config import LOG_DAEMON_ENCODING, LOG_DAEMON_TARGET_HOST, LOG_DAEMON_TARGET_PORT
+
+logger = logging.getLogger(__name__)
+
+
+class _UdpProtocol(asyncio.DatagramProtocol):
+    def __init__(self):
+        self.transport = None
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def datagram_received(self, data, addr):
+        ...
+
+    def error_received(self, ex):
+        logger.error("UDP error %s", ex)
+
+    def connection_lost(self, ex):
+        logger.error("UDP error / closed? %s", ex)
+
+
+async def udp_transport_loop(
+    queue: asyncio.Queue,
+    host: str = LOG_DAEMON_TARGET_HOST,
+    port: int = LOG_DAEMON_TARGET_PORT,
+) -> None:
+    """Ship messages from the queue to logstash at ``(host, port)`` over UDP."""
+    loop = asyncio.get_running_loop()
+    transport, _ = await loop.create_datagram_endpoint(
+        _UdpProtocol,
+        remote_addr=(host, port),
+    )
+    while True:
+        try:
+            item = await queue.get()
+            json_item = json.dumps(item).encode(LOG_DAEMON_ENCODING)
+            transport.sendto(json_item)
+        except Exception as ex:
+            logger.error("Failed to send message: %s", ex)
+            logger.debug("Failed to send message: %s", ex, exc_info=True)
+            await asyncio.sleep(0.01)

--- a/ads_log_daemon/main.py
+++ b/ads_log_daemon/main.py
@@ -152,7 +152,7 @@ class LdapLogger:
         logger.info("Looking for new hosts with LDAP...")
         self.ldap_update_deadline = time.monotonic() + LOG_DAEMON_SEARCH_PERIOD
         try:
-            self.recently_removed_hosts, _ = self.ld.update_hosts()
+            self.recently_removed_hosts, _ = self.ld.update_hosts_async()
         except Exception:
             logger.exception(
                 "Failed to update LDAP hosts. Waiting for twice the "

--- a/ads_log_daemon/main.py
+++ b/ads_log_daemon/main.py
@@ -192,6 +192,7 @@ async def main_ldap(handler: logging.Handler):
             await prune_tasks()
             await asyncio.sleep(0.5)
     finally:
+        logger.info("ldap_main exiting; cleaning up tasks...")
         for task in local_tasks:
             if task is not None:
                 task.cancel()

--- a/ads_log_daemon/main.py
+++ b/ads_log_daemon/main.py
@@ -134,7 +134,7 @@ async def main_ldap(handler: logging.Handler):
     udp_queue = asyncio.Queue()
     queue_task = asyncio.create_task(udp_transport_loop(udp_queue), name="queue_task")
     connection_status_task = asyncio.create_task(
-        show_connection_status, name="connection_status"
+        show_connection_status(), name="connection_status"
     )
     local_tasks = [queue_task, connection_status_task]
 

--- a/ads_log_daemon/main.py
+++ b/ads_log_daemon/main.py
@@ -176,7 +176,7 @@ class LdapLogger:
                     task.cancel()
                     try:
                         await task
-                    except asyncio.CancelledError:
+                    except Exception:
                         ...
 
     async def run(self):
@@ -226,7 +226,7 @@ class LdapLogger:
                     task.cancel()
                     try:
                         await task
-                    except asyncio.CancelledError:
+                    except Exception:
                         ...
 
 

--- a/ads_log_daemon/main.py
+++ b/ads_log_daemon/main.py
@@ -152,7 +152,7 @@ class LdapLogger:
         logger.info("Looking for new hosts with LDAP...")
         self.ldap_update_deadline = time.monotonic() + LOG_DAEMON_SEARCH_PERIOD
         try:
-            self.recently_removed_hosts, _ = self.ld.update_hosts_async()
+            self.recently_removed_hosts, _ = await self.ld.update_hosts_async()
         except Exception:
             logger.exception(
                 "Failed to update LDAP hosts. Waiting for twice the "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Single queue for logging to logstash on a per application basis
* LDAP-based PLC host discovery main entrypoint was the next big mess after #14 
* This changes the logic to reconnect to PLCs a bit quicker than the search rate and log more information
* Hoping that the refactor of plc host-to-task management might increase reliability
 
## Motivation and Context
* Don't need queues / UDP sockets for each client
